### PR TITLE
fix: added missing runner exports

### DIFF
--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -9,6 +9,16 @@ export interface MacroContext {
   ast: MacroAst;
   unpluginContext: UnpluginBuildContext & UnpluginContext;
 }
+export interface MacroRunner {
+  init?: () => Thenable<void>;
+  resolve: (_: string, _: string) => Thenable<string>;
+  import: (_: string) => Thenable<Record<string, unknown>>;
+  invalidate?: (_: string) => Thenable<Iterable<string> | undefined>;
+  close?: () => Thenable<void>;
+}
+export interface NativeRunnerOptions {
+  track?: boolean;
+}
 export interface Options {
   include?: FilterPattern;
   exclude?: FilterPattern;
@@ -28,12 +38,19 @@ export interface TransformContext {
 }
 // #endregion
 
+// #region Types
+export type UnrunRunnerOptions = Omit<Options, "path" | "preset">;
+// #endregion
+
 // #region Functions
 export declare function defineMacro<Args extends any[], Return>(_: (this: MacroContext, ..._: Args) => Return): (..._: Args) => Return;
-export declare function resolveOptions(_: Options): OptionsResolved;
+export declare function nativeRunner(_?: NativeRunnerOptions): MacroRunner;
+export declare function resolveMacroPath(_: string, _: string): string;
+export declare function resolveOptions(_: Options$1): OptionsResolved;
 export declare function transformMacros(_: TransformContext): Promise<void>;
+export declare function unrunRunner(_?: UnrunRunnerOptions): MacroRunner;
 // #endregion
 
 // #region Variables
-export declare const Macros: UnpluginInstance<Options | undefined, false>;
+export declare const Macros: UnpluginInstance<Options$1 | undefined, false>;
 // #endregion

--- a/__snapshots__/tsnapi/index.snapshot.js
+++ b/__snapshots__/tsnapi/index.snapshot.js
@@ -3,8 +3,11 @@
  */
 // #region Functions
 export function defineMacro(_) {}
+export function nativeRunner(_) {}
+export function resolveMacroPath(_, _) {}
 export function resolveOptions(_) {}
 export async function transformMacros(_) {}
+export function unrunRunner(_) {}
 // #endregion
 
 // #region Variables

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   type TransformContext,
 } from './core/index.ts'
 export { resolveOptions, type Options } from './core/options.ts'
+export * from './runner/index.ts';
 
 /**
  * The main unplugin instance.


### PR DESCRIPTION
### Description

The examples show how to use the runners, but the runners themselves aren't exported 😅